### PR TITLE
Fix module path to match GitHub repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ A CLI tool that manages multiple AI coding agent worktree sessions via tmux.
 ## Installation
 
 ```bash
-go install github.com/shoito/kage@latest
+go install github.com/Sean0628/kage@latest
 ```
 
 Or build from source:
 
 ```bash
-git clone https://github.com/shoito/kage.git
+git clone https://github.com/Sean0628/kage.git
 cd kage
 go build -o bin/kage .
 ```

--- a/cmd/dash.go
+++ b/cmd/dash.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/shoito/kage/internal/tui"
+	"github.com/Sean0628/kage/internal/tui"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/shoito/kage/internal/config"
-	"github.com/shoito/kage/internal/tmux"
+	"github.com/Sean0628/kage/internal/config"
+	"github.com/Sean0628/kage/internal/tmux"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shoito/kage
+module github.com/Sean0628/kage
 
 go 1.26.1
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -3,9 +3,9 @@ package project
 import (
 	"fmt"
 
-	"github.com/shoito/kage/internal/config"
-	"github.com/shoito/kage/internal/tmux"
-	"github.com/shoito/kage/internal/worktree"
+	"github.com/Sean0628/kage/internal/config"
+	"github.com/Sean0628/kage/internal/tmux"
+	"github.com/Sean0628/kage/internal/worktree"
 )
 
 // FeatureStatus represents the state of a feature branch.

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shoito/kage/internal/config"
+	"github.com/Sean0628/kage/internal/config"
 )
 
 // WindowInfo represents a tmux window.

--- a/internal/tui/dashboard.go
+++ b/internal/tui/dashboard.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/shoito/kage/internal/project"
+	"github.com/Sean0628/kage/internal/project"
 )
 
 // listItem is a flattened item in the dashboard list.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/shoito/kage/internal/config"
-	"github.com/shoito/kage/internal/project"
-	"github.com/shoito/kage/internal/worktree"
+	"github.com/Sean0628/kage/internal/config"
+	"github.com/Sean0628/kage/internal/project"
+	"github.com/Sean0628/kage/internal/worktree"
 )
 
 // Mode represents the current TUI mode.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/shoito/kage/cmd"
+import "github.com/Sean0628/kage/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
  ## Summary

  - The Go module was declared as `github.com/shoito/kage` but the repo lives at `github.com/Sean0628/kage`
  - This caused `go install github.com/Sean0628/kage@latest` to fail with a module path mismatch error

  ## Changes

  - Updated `go.mod` module declaration to `github.com/Sean0628/kage`
  - Updated all internal imports across `main.go`, `cmd/`, `internal/` packages
  - Fixed `go install` command and clone URL in `README.md`

  ## Test plan

  - [ ] `go install github.com/Sean0628/kage@latest` installs successfully
  - [ ] `go build -o bin/kage .` builds from source
  - [ ] CI passes