### PR TITLE
Add detached option to SplitWindowWithCmd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,14 +120,12 @@ func setupCoordinatorPane(cfg *config.Config) {
 	// Split dashboard window: left = TUI, right = coordinator
 	// Use SplitWindowWithCmd to run the agent directly, avoiding the race condition
 	// where SendKeys fires before the shell in the new pane is ready.
+	// Detached=true keeps focus on the dashboard (pane 0).
 	target := tmux.SessionName + ":dashboard"
-	if err := tmux.SplitWindowWithCmd(target, true, "50", cfg.EffectiveWorkspace(), coordinatorCmd); err != nil {
+	if err := tmux.SplitWindowWithCmd(target, true, "50", cfg.EffectiveWorkspace(), coordinatorCmd, true); err != nil {
 		fmt.Fprintf(os.Stderr, "kage: failed to split dashboard for coordinator: %v\n", err)
 		return
 	}
-
-	// Select the left pane (TUI) as active
-	tmux.RunSilent("select-pane", "-t", target+".0")
 }
 
 // buildCoordinatorCmd returns the shell command to launch the coordinator agent

--- a/internal/tmux/window.go
+++ b/internal/tmux/window.go
@@ -69,12 +69,16 @@ func SplitWindow(target string, horizontal bool, size string, startDir string) e
 // Unlike SplitWindow + SendKeys, this avoids the race condition where keystrokes
 // arrive before the shell is ready. The pane is set to remain-on-exit so it
 // stays open if the command exits.
-func SplitWindowWithCmd(target string, horizontal bool, size string, startDir string, cmd string) error {
+// If detached is true, the original pane retains focus.
+func SplitWindowWithCmd(target string, horizontal bool, size string, startDir string, cmd string, detached bool) error {
 	flag := "-h" // side by side
 	if horizontal {
 		flag = "-v" // top/bottom
 	}
 	args := []string{"split-window", flag, "-t", target}
+	if detached {
+		args = append(args, "-d")
+	}
 	if size != "" {
 		args = append(args, "-p", strings.TrimSuffix(size, "%"))
 	}
@@ -236,7 +240,7 @@ func SetupLayoutTree(windowTarget string, node *config.LayoutNode, paneTarget st
 		// For leaf children with commands, use SplitWindowWithCmd to avoid
 		// the race condition where SendKeys fires before the shell is ready.
 		if child.IsLeaf() && child.Cmd != "" && child.Cmd != "shell" {
-			if err := SplitWindowWithCmd(currentPane, horizontal, sizeStr, workDir, child.Cmd); err != nil {
+			if err := SplitWindowWithCmd(currentPane, horizontal, sizeStr, workDir, child.Cmd, false); err != nil {
 				return fmt.Errorf("splitting for child %d: %w", i+1, err)
 			}
 			cmdHandled[i+1] = true


### PR DESCRIPTION
## Summary
- Add a `detached` bool parameter to `SplitWindowWithCmd` so callers can use tmux's native `-d` flag to keep focus on the original pane
- Use this in `setupCoordinatorPane` to keep the dashboard focused, removing the separate `select-pane` call and eliminating a potential race

## Test plan
- [ ] Run `kage` with coordinator mode enabled and verify the dashboard (pane 0) retains focus after the coordinator pane is created
- [ ] Launch a feature with a tree layout and verify pane splits still work correctly (non-detached path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)