### PR TITLE
Fix diagram alignment and demo tape keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,41 +12,41 @@ A CLI tool that manages multiple AI coding agent worktree sessions via tmux.
 ![kage demo](./assets/demo.gif)
 
 ```
-                          ┌──────────────────────────────────┐
-                          │        kage TUI Dashboard        │
-                          │  ┌─────────────────────────────┐ │
-                          │  │ ● app/feat-auth        [3p] │ │
-                          │  │   app/feat-search      [3p] │ │
-                          │  │   app/fix-login        [3p] │ │
-                          │  │                             │ │
-                          │  │ n:new  enter:jump  d:delete │ │
-                          │  └─────────────────────────────┘ │
-                          └──────────────┬───────────────────┘
-                                         │
-                      ┌──────────────────┼──────────────────┐
-                      │                  │                  │
-                      ▼                  ▼                  ▼
-              ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
-              │ tmux window  │  │ tmux window  │  │ tmux window  │
-              │ feat-auth    │  │ feat-search  │  │ fix-login    │
-              │┌────────────┐│  │┌────────────┐│  │┌────────────┐│
-              ││ Claude Code ││  ││   Aider    ││  ││   Codex    ││
-              ││   (60%)    ││  ││   (60%)    ││  ││   (60%)    ││
-              │├────────────┤│  │├────────────┤│  │├────────────┤│
-              ││ shell (20%)││  ││ shell (20%)││  ││ shell (20%)││
-              │├────────────┤│  │├────────────┤│  │├────────────┤│
-              ││ shell (20%)││  ││ shell (20%)││  ││ shell (20%)││
-              │└────────────┘│  │└────────────┘│  │└────────────┘│
-              └──────┬───────┘  └──────┬───────┘  └──────┬───────┘
-                     │                 │                 │
-                     ▼                 ▼                 ▼
-              ┌──────────────┐  ┌──────────────┐  ┌──────────────┐
-              │ git worktree │  │ git worktree │  │ git worktree │
-              │ app-feat-auth│  │app-feat-search│ │ app-fix-login│
-              └──────────────┘  └──────────────┘  └──────────────┘
+                         ┌───────────────────────────────────┐
+                         │         kage TUI Dashboard        │
+                         │  ┌─────────────────────────────┐  │
+                         │  │ ● app/feat-auth        [3p] │  │
+                         │  │   app/feat-search      [3p] │  │
+                         │  │   app/fix-login        [3p] │  │
+                         │  │                             │  │
+                         │  │ n:new  enter:jump  d:delete │  │
+                         │  └─────────────────────────────┘  │
+                         └─────────────────┬─────────────────┘
+                                           │
+                       ┌───────────────────┼───────────────────┐
+                       │                   │                   │
+                       ▼                   ▼                   ▼
+              ┌────────────────┐  ┌────────────────┐  ┌────────────────┐
+              │   tmux window  │  │   tmux window  │  │   tmux window  │
+              │   feat-auth    │  │  feat-search   │  │   fix-login    │
+              │┌──────────────┐│  │┌──────────────┐│  │┌──────────────┐│
+              ││ Claude Code  ││  ││    Aider     ││  ││    Codex     ││
+              ││    (60%)     ││  ││    (60%)     ││  ││    (60%)     ││
+              │├──────────────┤│  │├──────────────┤│  │├──────────────┤│
+              ││ shell (20%)  ││  ││ shell (20%)  ││  ││ shell (20%)  ││
+              │├──────────────┤│  │├──────────────┤│  │├──────────────┤│
+              ││ shell (20%)  ││  ││ shell (20%)  ││  ││ shell (20%)  ││
+              │└──────────────┘│  │└──────────────┘│  │└──────────────┘│
+              └────────┬───────┘  └────────┬───────┘  └────────┬───────┘
+                       │                   │                   │
+                       ▼                   ▼                   ▼
+              ┌────────────────┐  ┌────────────────┐  ┌────────────────┐
+              │  git worktree  │  │  git worktree  │  │  git worktree  │
+              │ app-feat-auth  │  │app-feat-search │  │ app-fix-login  │
+              └────────────────┘  └────────────────┘  └────────────────┘
 
-         Each "shadow clone" works independently in its own
-           isolated worktree — no conflicts, no interference.
+          Each "shadow clone" works independently in its own
+            isolated worktree — no conflicts, no interference.
 ```
 
 ## Features

--- a/demo.tape
+++ b/demo.tape
@@ -32,10 +32,10 @@ Sleep 500ms
 Enter
 Sleep 3s
 
-# Return to dashboard (Ctrl+a 1)
+# Return to dashboard (Ctrl+a K)
 Ctrl+a
 Sleep 300ms
-Type "1"
+Type "K"
 Sleep 2s
 
 # Delete the feature


### PR DESCRIPTION
## Summary
- Widen tmux/worktree boxes in README diagram to 18 chars so `app-feat-search` fits without overflowing
- Fix asymmetric inner box padding and align all connectors (`┬`, `┼`, `▼`) with box centers
- Update `demo.tape` to use `Ctrl+a K` instead of `Ctrl+a 1` to match the actual registered keybinding

## Test plan
- [ ] Verify diagram renders correctly on GitHub
- [ ] Run `vhs demo.tape` to confirm the demo GIF records correctly with the updated keybinding

🤖 Generated with [Claude Code](https://claude.com/claude-code)